### PR TITLE
Properly fix common variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,15 @@
 
 # -m386 (486,pentium,pentiumpro)
 #OPTIMIZE=-O7 -mpentiumpro
-OPTIMIZE=-O3
+OPTIMIZE?=-O3
 
 # debug symbols will be stripped anyway during 'make install'
-DEBUG=-g
+DEBUG?=-g
 
 #### DON'T CHANGE ANYTHING BELOW ####
-DESTDIR=/usr/local
-CFLAGS=-Wall $(OPTIMIZE) $(DEBUG) -fcommon # use "-fcommon" for this bug https://stackoverflow.com/questions/69908418/multiple-definition-of-first-defined-here-on-gcc-10-2-1-but-not-gcc-8-3-0
-LIBS=-lm
-CC=gcc
+DESTDIR?=/usr/local
+CFLAGS?=-Wall $(OPTIMIZE) $(DEBUG) # -fcommon # use "-fcommon" for this bug https://stackoverflow.com/questions/69908418/multiple-definition-of-first-defined-here-on-gcc-10-2-1-but-not-gcc-8-3-0
+LIBS?=-lm
 
 DEPS=mls.h mls_mime.h mls_text.h mls_list.h mls_stat.h
 OBJS=mls.o mls_mime.o mls_text.o mls_list.o mls_stat.o

--- a/mls.c
+++ b/mls.c
@@ -51,6 +51,14 @@ time_t t;          // actual time - to be added to output
 time_t t_oldest,
        t_newest;   // date of oldest/newest message found
 
+// Reg. expressions
+regex_t r_from, r_time, r_re, r_date, r_dow, r_mail,
+        r_m_ims, r_m_bat, r_m_lot, r_m_oue, r_m_ouc, r_m_oum, r_m_out,
+	r_m_cal, r_m_moz, r_m_peg, r_m_eud, r_m_ope, r_m_opw, r_m_pos,
+	r_m_pob, r_m_kma, r_m_imp, r_m_mut, r_m_pin, r_m_pi2, r_m_syl,
+	r_m_pan, r_m_4td, r_m_fag, r_m_mpg, r_m_xws, r_m_knd, r_m_hst,
+	r_m_nnr;
+
 /* ************************************************* Other * FUNCTIONS *** */
 /* ***** banner ********************************************************** */
 void banner() { // print greeting banner

--- a/mls.h
+++ b/mls.h
@@ -104,7 +104,7 @@ struct bestTEXT {
 };
 
 // Reg. expressions
-regex_t r_from, r_time, r_re, r_date, r_dow, r_mail,
+extern regex_t r_from, r_time, r_re, r_date, r_dow, r_mail,
         r_m_ims, r_m_bat, r_m_lot, r_m_oue, r_m_ouc, r_m_oum, r_m_out,
 	r_m_cal, r_m_moz, r_m_peg, r_m_eud, r_m_ope, r_m_opw, r_m_pos,
 	r_m_pob, r_m_kma, r_m_imp, r_m_mut, r_m_pin, r_m_pi2, r_m_syl,

--- a/mls_mime.c
+++ b/mls_mime.c
@@ -22,6 +22,8 @@
 #include "mls_mime.h"
 #include "mls_stat.h"
 
+regex_t r_qp, r_base64, r_hex;
+
 void replaceStr(char *input, int so, int eo, char *repl) {
  // replace part of input from index so to eo with repl
  // repl should be smaller than eo-so+1!

--- a/mls_mime.h
+++ b/mls_mime.h
@@ -21,7 +21,7 @@
 #ifndef	_MLS_MIME_H
 #define	_MLS_MIME_H	1
 
-regex_t r_qp, r_base64, r_hex;
+extern regex_t r_qp, r_base64, r_hex;
 
 /* ********************************************* FUNCTION DECLARATIONS *** */
 int base64_table(char *lookup);

--- a/mls_stat.c
+++ b/mls_stat.c
@@ -379,7 +379,7 @@ void ParseInput() { // parse whole input file
        }
        // will search for mailers in these
        // Message-ID will be used only if no other of these is present
-       if (!strncasecmp(riadok,"Message-ID: ",12) && sMail=='\0') { // for Pine mailer
+       if (!strncasecmp(riadok,"Message-ID: ",12) && *sMail=='\0') { // for Pine mailer
           myCopy(sMail,riadok+12,MAX_SUBJ);
 	  GetMailer(sMail);
        }


### PR DESCRIPTION
Declare common variable as extern in header files, define them in apropriate source files.